### PR TITLE
Add Transparent theme with transparent background

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Simply add the _theme_ parameter to the url like so:
 |             `sky` <br /> ![sky][sky]             |                 `beach` <br /> ![beach][beach]                  |
 | `purple-gang` <br /> ![purple-gang][purple-gang] |                   `mint` <br /> ![mint][mint]                   |
 |          `leafy` <br /> ![leafy][leafy]          |                 `black` <br /> ![black][black]                  |
+|    `invisible` <br /> ![invisible][invisible]    |                                                                 |
 
 [light]: https://leetcode-badge-showcase.vercel.app/api?username=kevzpeter&theme=light&filter=study
 [dark]: https://leetcode-badge-showcase.vercel.app/api?username=kevzpeter&theme=dark&filter=study
@@ -116,6 +117,7 @@ Simply add the _theme_ parameter to the url like so:
 [mint]: https://leetcode-badge-showcase.vercel.app/api?username=kevzpeter&theme=mint&filter=study
 [leafy]: https://leetcode-badge-showcase.vercel.app/api?username=kevzpeter&theme=leafy&filter=study
 [black]: https://leetcode-badge-showcase.vercel.app/api?username=kevzpeter&theme=black&filter=study
+[invisible]: https://leetcode-badge-showcase.vercel.app/api?username=kevzpeter&theme=invisible&filter=study
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Simply add the _theme_ parameter to the url like so:
 |             `sky` <br /> ![sky][sky]             |                 `beach` <br /> ![beach][beach]                  |
 | `purple-gang` <br /> ![purple-gang][purple-gang] |                   `mint` <br /> ![mint][mint]                   |
 |          `leafy` <br /> ![leafy][leafy]          |                 `black` <br /> ![black][black]                  |
-|    `invisible` <br /> ![invisible][invisible]    |                                                                 |
+|    `transparent` <br /> ![transparent][transparent]    |                                                                 |
 
 [light]: https://leetcode-badge-showcase.vercel.app/api?username=kevzpeter&theme=light&filter=study
 [dark]: https://leetcode-badge-showcase.vercel.app/api?username=kevzpeter&theme=dark&filter=study
@@ -117,7 +117,7 @@ Simply add the _theme_ parameter to the url like so:
 [mint]: https://leetcode-badge-showcase.vercel.app/api?username=kevzpeter&theme=mint&filter=study
 [leafy]: https://leetcode-badge-showcase.vercel.app/api?username=kevzpeter&theme=leafy&filter=study
 [black]: https://leetcode-badge-showcase.vercel.app/api?username=kevzpeter&theme=black&filter=study
-[invisible]: https://leetcode-badge-showcase.vercel.app/api?username=kevzpeter&theme=invisible&filter=study
+[transparent]: https://leetcode-badge-showcase.vercel.app/api?username=kevzpeter&theme=transparent&filter=study
 
 <br/>
 

--- a/components/SvgWidget.tsx
+++ b/components/SvgWidget.tsx
@@ -6,6 +6,9 @@ import themes from '../utils/themes.json';
  */
 export default function SvgWidget({ response, username, imgSource, theme, border, animated }): JSX.Element {
     const borderStyle = border === 'border' ? '1px solid #E4E2E2' : 'none';
+    // Make SVG have transparent background if using invisible theme
+    const isTransparent = theme === 'invisible';
+    
     return (
         <g>
             <foreignObject x="0" y="0" width="100%" height="100%">
@@ -14,16 +17,16 @@ export default function SvgWidget({ response, username, imgSource, theme, border
                         <div
                             className="showCase"
                             style={{
-                                'background-color': `${themes[theme].background}`,
-                                'border': borderStyle,
+                                backgroundColor: `${themes[theme].background}`,
+                                border: borderStyle,
                             }}
                         >
                             <div>
-                                <span style={{ 'color': `${themes[theme].colorPrimary}` }} className='header'>
+                                <span style={{ color: `${themes[theme].colorPrimary}` }} className='header'>
                                     <img src={imgSource} alt="LeetCode Logo" title="LeetCode Logo" width={36} height={36} />
                                     <span>{username} LeetCode Badges</span>
                                 </span>
-                                <hr style={{ 'background-color': `${themes[theme].colorSecondary}` }} />
+                                <hr style={{ backgroundColor: `${themes[theme].colorSecondary}` }} />
                             </div>
                             {response?.map((category: Object, index: number) => {
                                 return (<Category category={category} key={index} theme={theme} border={border} animated={animated} />)

--- a/components/SvgWidget.tsx
+++ b/components/SvgWidget.tsx
@@ -6,8 +6,8 @@ import themes from '../utils/themes.json';
  */
 export default function SvgWidget({ response, username, imgSource, theme, border, animated }): JSX.Element {
     const borderStyle = border === 'border' ? '1px solid #E4E2E2' : 'none';
-    // Make SVG have transparent background if using invisible theme
-    const isTransparent = theme === 'invisible';
+    // Make SVG have transparent background if using transparent theme
+    const isTransparent = theme === 'transparent';
     
     return (
         <g>

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -3,7 +3,7 @@ export const BASEURL = "https://leetcode-badge-showcase.vercel.app";
 export const LEETCODE_BASEURL = "https://leetcode.com";
 
 export const THEME_NAMES = ['light', 'dark', 'sky', 'beach', 'github-dark', 'nightowl',
-    'tokyonight', 'onedark', 'dracula', 'monokai', 'shades-of-purple', 'cobalt2', 'mint', 'purple-gang', 'leafy', 'black'];
+    'tokyonight', 'onedark', 'dracula', 'monokai', 'shades-of-purple', 'cobalt2', 'mint', 'purple-gang', 'leafy', 'black', 'invisible'];
 
 export const FILTERS = {
     daily: 'DCC',

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -3,7 +3,7 @@ export const BASEURL = "https://leetcode-badge-showcase.vercel.app";
 export const LEETCODE_BASEURL = "https://leetcode.com";
 
 export const THEME_NAMES = ['light', 'dark', 'sky', 'beach', 'github-dark', 'nightowl',
-    'tokyonight', 'onedark', 'dracula', 'monokai', 'shades-of-purple', 'cobalt2', 'mint', 'purple-gang', 'leafy', 'black', 'invisible'];
+    'tokyonight', 'onedark', 'dracula', 'monokai', 'shades-of-purple', 'cobalt2', 'mint', 'purple-gang', 'leafy', 'black', 'transparent'];
 
 export const FILTERS = {
     daily: 'DCC',

--- a/utils/generateSVG.tsx
+++ b/utils/generateSVG.tsx
@@ -41,6 +41,7 @@ export function generateSvg(response: Array<any>, username: string, imgSource: s
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
         font-family="Segoe UI, sans-serif"
+        ${theme === 'invisible' ? 'style="background: transparent;"' : ''}
     >
     <style>${allStyles}</style>
     ${svgBody}

--- a/utils/generateSVG.tsx
+++ b/utils/generateSVG.tsx
@@ -41,7 +41,7 @@ export function generateSvg(response: Array<any>, username: string, imgSource: s
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
         font-family="Segoe UI, sans-serif"
-        ${theme === 'invisible' ? 'style="background: transparent;"' : ''}
+        ${theme === 'transparent' ? 'style="background: transparent;"' : ''}
     >
     <style>${allStyles}</style>
     ${svgBody}

--- a/utils/themes.json
+++ b/utils/themes.json
@@ -78,5 +78,10 @@
     "background": "#000",
     "colorPrimary": "#efefef",
     "colorSecondary": "#fff"
+  },
+  "invisible": {
+    "background": "transparent",
+    "colorPrimary": "#0070f3",
+    "colorSecondary": "#034078"
   }
 }

--- a/utils/themes.json
+++ b/utils/themes.json
@@ -79,7 +79,7 @@
     "colorPrimary": "#efefef",
     "colorSecondary": "#fff"
   },
-  "invisible": {
+  "transparent": {
     "background": "transparent",
     "colorPrimary": "#0070f3",
     "colorSecondary": "#034078"


### PR DESCRIPTION
# Description
## What does this PR implement?
This PR adds a new "Transparent" theme that renders badges with a transparent background while maintaining readable text colors. This allows badges to blend seamlessly with any GitHub README background.

## Why is this useful?
- Improves visual integration with custom README styles and themes
- Provides better compatibility with GitHub's dark mode
- Offers more flexibility for users who want badges to match their existing page design

## Implementation details
- Added "Transparent" to the available themes list in `config.ts`
- Added theme configuration to `themes.json` with transparent background
- Updated SVG generation to support transparency
- Added documentation in the README with an example
- Fixed React-specific styling warnings (camelCase vs kebab-case)

## Testing
- Tested locally with various badge combinations
- Tested with Vercel deployment
- Verified transparent background renders correctly
- Confirmed compatibility with both light and dark GitHub themes

## Screenshots
<img width="1624" alt="Screenshot 2025-05-11 at 11 36 48 PM" src="https://github.com/user-attachments/assets/78c39cc6-0060-4f1e-bf17-b043b45baea6" />
<img width="1624" alt="Screenshot 2025-05-11 at 11 37 30 PM" src="https://github.com/user-attachments/assets/e5909e26-6bad-4263-9501-13178dfe2796" />

